### PR TITLE
Use environment variable JULIA_ARRAYFIRE_BACKEND to set initial backend

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -32,6 +32,22 @@ global const bcast = Ref{Bool}(false)
 
 function __init__()
     Libdl.dlopen(af_lib)
+
+    backend_envvar_name = "JULIA_ARRAYFIRE_BACKEND"
+    if haskey(ENV, backend_envvar_name)
+        backend_str = lowercase(ENV[backend_envvar_name])
+        backends = Dict(
+            "cpu" => AF_BACKEND_CPU,
+            "cuda" => AF_BACKEND_CUDA,
+            "opencl" => AF_BACKEND_OPENCL
+        )
+        if haskey(backends, backend_str)
+            set_backend(backends[backend_str])
+        else
+            error("Unknown arrayfire backend \"$backend_str\".")
+        end
+    end
+
     afinit()
     afinfo()
     nothing


### PR DESCRIPTION
When using the unified backend, ArrayFire may select a non-functional backend by default (e.g. select CUDA because the libraries are in place even though there's no CUDA-compatible device in the machine). This can cause ArrayFire to crash, so the user doesn't get a chance to switch backend.

I propose to use a new environment variable `JULIA_ARRAYFIRE_BACKEND` to select the initial ArrayFire backend (ArrayFire itself doesn't seem to have an env variable for this, at least I didn't find one in the documentation). This also makes it possible easy to run code with different backends without selecting the backend in the user code.